### PR TITLE
fix: Rename .env.example to env.template

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ To get a local copy up and running, follow these simple steps.
     npm install
     ```
 3.  **Set up environment variables:**
-    Create a `.env` file in the `backend` directory by copying the example file:
+    Create a `.env` file in the `backend` directory by copying the template file:
     ```sh
-    cp .env.example .env
+    cp env.template .env
     ```
     Update the `.env` file with your database connection string and a secure JWT secret.
 

--- a/backend/env.template
+++ b/backend/env.template
@@ -1,0 +1,10 @@
+# Server Configuration
+PORT=5000
+NODE_ENV=development
+
+# Database
+MONGODB_URI=mongodb://localhost:27017/dagboek
+
+# Security
+JWT_SECRET=your_super_secret_jwt_key
+FRONTEND_URL=http://localhost:5173


### PR DESCRIPTION
- Renames the environment variable template file from `.env.example` to `env.template` to prevent it from being ignored by version control.
- Updates the `README.md` to reflect the new filename in the setup instructions.