### PR TITLE
feat: Add default admin user seeding and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ To get a local copy up and running, follow these simple steps.
     ```
     The server will be running on `http://localhost:5000`.
 
+    > **Note:** The first time you run the backend server, it will automatically create a default admin account with the following credentials:
+    > - **Email:** `admin@dagboek.com`
+    > - **Password:** `password`
+
 ## Roadmap
 
 - [x] Add a backend to persist data


### PR DESCRIPTION
- Implements a seeding function in `backend/server.js` that automatically creates a default admin user on the first server startup.
- This resolves the initial setup issue where no admin exists to approve new user registrations.
- Updates the `README.md` to document the MongoDB requirement and the credentials for the default admin user (`admin@dagboek.com` / `password`).